### PR TITLE
Test routing level refacto

### DIFF
--- a/solar_router/engine.yaml
+++ b/solar_router/engine.yaml
@@ -69,7 +69,7 @@ number:
     unit_of_measurement: "%"
     optimistic: True
     mode: slider
-    internal: True
+    internal: ${hide_regulators}
     on_value:
       then:
         - script.execute: regulation_control

--- a/solar_router/engine_common.yaml
+++ b/solar_router/engine_common.yaml
@@ -13,6 +13,8 @@ substitutions:
   # By default led are pin control is not inverted
   green_led_inverted: "False"
   yellow_led_inverted: "False"
+  # By default regulators are hidden
+  expose_regulators: "False"
 
 # Component managing time.
 # If activate switch is ON, power measurment and energy regulation are performed every secondes

--- a/solar_router/engine_common.yaml
+++ b/solar_router/engine_common.yaml
@@ -14,7 +14,7 @@ substitutions:
   green_led_inverted: "False"
   yellow_led_inverted: "False"
   # By default regulators are hidden
-  expose_regulators: "False"
+  hide_regulators: "True"
 
 # Component managing time.
 # If activate switch is ON, power measurment and energy regulation are performed every secondes

--- a/solar_router/engine_on_off.yaml
+++ b/solar_router/engine_on_off.yaml
@@ -54,7 +54,6 @@ number:
     min_value: 0
     initial_value: 0
     max_value: 100
-    internal: True
     unit_of_measurement: "%"
     optimistic: True
     on_value:

--- a/solar_router/engine_on_off.yaml
+++ b/solar_router/engine_on_off.yaml
@@ -24,7 +24,7 @@ switch:
             id(power_meter_activated) = 0;
             id(start_tempo_counter).publish_state(NAN);
             id(stop_tempo_counter).publish_state(NAN);
-            id(energy_divertion).turn_off();
+            id(router_level).publish_state(0);
 
   # Define if energy has to be diverted or not.
   # Reset counter, manage router level (0 or 100) and manage LEDs

--- a/solar_router/engine_on_off.yaml
+++ b/solar_router/engine_on_off.yaml
@@ -32,29 +32,13 @@ switch:
     name: "Energy divertion"
     id: energy_divertion
     optimistic: True
+    internal: ${hide_regulators}
     on_turn_on:
       then:
-        - lambda: |-
-            id(router_level).publish_state(100);
-            id(start_tempo_counter).publish_state(NAN);
-            id(stop_tempo_counter).publish_state(NAN);
         - script.execute: regulation_control
-        - light.turn_on:
-            id: green_led
-            effect: blink
     on_turn_off:
       then:
-        - lambda: |-
-            id(router_level).publish_state(0);
-            id(start_tempo_counter).publish_state(NAN);
-            id(stop_tempo_counter).publish_state(NAN);
         - script.execute: regulation_control
-        - light.turn_off: green_led
-        - if:
-            condition:
-              - switch.is_on: activate
-            then:
-              - light.turn_on: green_led
 
 number:
   # Router level 0 OR 100
@@ -73,6 +57,32 @@ number:
     internal: True
     unit_of_measurement: "%"
     optimistic: True
+    on_value:
+      then:
+        - if:
+            condition:
+              number.in_range:
+                id: router_level
+                above: 1
+            then:
+              - switch.turn_on: energy_divertion
+              - lambda: |-
+                  id(start_tempo_counter).publish_state(NAN);
+                  id(stop_tempo_counter).publish_state(NAN);
+              - light.turn_on:
+                  id: green_led
+                  effect: blink
+            else:
+              - switch.turn_off: energy_divertion
+              - lambda: |-
+                  id(start_tempo_counter).publish_state(NAN);
+                  id(stop_tempo_counter).publish_state(NAN);
+              - light.turn_off: green_led
+              - if:
+                  condition:
+                    - switch.is_on: activate
+                  then:
+                    - light.turn_on: green_led
   
   # Define the power level to start divertion
   - platform: template
@@ -155,13 +165,13 @@ script:
       - lambda: |-
           if (isnan(id(real_power).state) or id(safety_limit)){
             // If we can have information about grid exchange or if safety_limit is active, do not divert any energy
-            id(energy_divertion).turn_off();
+            id(router_level).publish_state(0);
             return;
           }
           if (id(real_power).state < -id(start_power_level).state) 
           {
             // Energy divertion is needed
-            if ( id(energy_divertion).state ){
+            if ( id(router_level).state >= 100 ){
               // Energy divertion is already done
               id(start_tempo_counter).publish_state(NAN);
               return;
@@ -175,7 +185,7 @@ script:
             id(start_tempo_counter).publish_state(id(start_tempo_counter).state - 1);
             if (id(start_tempo_counter).state <= 0)
             {
-              id(energy_divertion).turn_on();
+              id(router_level).publish_state(100);
               id(start_tempo_counter).publish_state(NAN);
             }
             return;
@@ -183,7 +193,7 @@ script:
           if (id(real_power).state > -id(stop_power_level).state) 
           {
             // If energy divertion need to be stopped
-            if (not id(energy_divertion).state){
+            if (id(router_level).state <= 0){
               // Energy divertion is already stopped
               id(stop_tempo_counter).publish_state(NAN);
               return;
@@ -197,7 +207,7 @@ script:
             id(stop_tempo_counter).publish_state(id(stop_tempo_counter).state - 1);
             if (id(stop_tempo_counter).state <= 0)
             {
-              id(energy_divertion).turn_off();
+              id(router_level).publish_state(0);
               id(stop_tempo_counter).publish_state(NAN);
             }
             return;


### PR DESCRIPTION
- Created substitution `hide_regulators`, True by default to hide the controls of regulators (as it can be redondant when the router has a single regulator).
- Moved `engine_on_off` to use `router_level`. Logic is done on `router_level` (0 or 100). `router_level` then update the regulator `energy_divertion`.
- LED and energy counter and start&stop tempo logic is now computed based on `router_level`